### PR TITLE
Added processors & support for AppKit objects (Interface Builder Version 3.1.4 (680))

### DIFF
--- a/Command Line/Command Line.xcodeproj/project.pbxproj
+++ b/Command Line/Command Line.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 45;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -55,6 +55,26 @@
 		3A1CCF7814684EFA00E639D4 /* UIViewControllerProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1CCF4814684EFA00E639D4 /* UIViewControllerProcessor.m */; };
 		3A1CCF7914684EFA00E639D4 /* UIViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1CCF4A14684EFA00E639D4 /* UIViewProcessor.m */; };
 		3A1CCF7A14684EFA00E639D4 /* UIWebViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1CCF4C14684EFA00E639D4 /* UIWebViewProcessor.m */; };
+		C36F0DAB1508F3F600A96F84 /* NSArrayControllerProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D861508F3F600A96F84 /* NSArrayControllerProcessor.m */; };
+		C36F0DAC1508F3F600A96F84 /* NSBoxProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D881508F3F600A96F84 /* NSBoxProcessor.m */; };
+		C36F0DAD1508F3F600A96F84 /* NSButtonCellProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D8A1508F3F600A96F84 /* NSButtonCellProcessor.m */; };
+		C36F0DAE1508F3F600A96F84 /* NSButtonProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D8C1508F3F600A96F84 /* NSButtonProcessor.m */; };
+		C36F0DAF1508F3F600A96F84 /* NSCellProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D8E1508F3F600A96F84 /* NSCellProcessor.m */; };
+		C36F0DB01508F3F600A96F84 /* NSCollectionViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D901508F3F600A96F84 /* NSCollectionViewProcessor.m */; };
+		C36F0DB11508F3F600A96F84 /* NSCustomViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D921508F3F600A96F84 /* NSCustomViewProcessor.m */; };
+		C36F0DB21508F3F600A96F84 /* NSImageCellProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D941508F3F600A96F84 /* NSImageCellProcessor.m */; };
+		C36F0DB31508F3F600A96F84 /* NSImageViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D961508F3F600A96F84 /* NSImageViewProcessor.m */; };
+		C36F0DB41508F3F600A96F84 /* NSPopUpButtonCellProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D981508F3F600A96F84 /* NSPopUpButtonCellProcessor.m */; };
+		C36F0DB51508F3F600A96F84 /* NSPopUpButtonProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D9A1508F3F600A96F84 /* NSPopUpButtonProcessor.m */; };
+		C36F0DB61508F3F600A96F84 /* NSScrollerProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D9C1508F3F600A96F84 /* NSScrollerProcessor.m */; };
+		C36F0DB71508F3F600A96F84 /* NSScrollViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0D9E1508F3F600A96F84 /* NSScrollViewProcessor.m */; };
+		C36F0DB81508F3F600A96F84 /* NSSearchFieldCellProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0DA01508F3F600A96F84 /* NSSearchFieldCellProcessor.m */; };
+		C36F0DB91508F3F600A96F84 /* NSSearchFieldProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0DA21508F3F600A96F84 /* NSSearchFieldProcessor.m */; };
+		C36F0DBA1508F3F600A96F84 /* NSTextFieldCellProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0DA41508F3F600A96F84 /* NSTextFieldCellProcessor.m */; };
+		C36F0DBB1508F3F600A96F84 /* NSTextFieldProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0DA61508F3F600A96F84 /* NSTextFieldProcessor.m */; };
+		C36F0DBC1508F3F600A96F84 /* NSViewProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0DA81508F3F600A96F84 /* NSViewProcessor.m */; };
+		C36F0DBD1508F3F600A96F84 /* NSWindowTemplateProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = C36F0DAA1508F3F600A96F84 /* NSWindowTemplateProcessor.m */; };
+		C36F0E051508F8BA00A96F84 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C36F0E041508F8BA00A96F84 /* AppKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -71,7 +91,7 @@
 
 /* Begin PBXFileReference section */
 		3A1CCED114684E1200E639D4 /* nib2objc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = nib2objc; sourceTree = BUILT_PRODUCTS_DIR; };
-		3A1CCED514684E1200E639D4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		3A1CCED514684E1200E639D4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		3A1CCED814684E1200E639D4 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3A1CCEDB14684E1200E639D4 /* nib2objc-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "nib2objc-Prefix.pch"; sourceTree = "<group>"; };
 		3A1CCEF014684EFA00E639D4 /* NSDictionary+Nib2ObjcExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Nib2ObjcExtensions.h"; sourceTree = "<group>"; };
@@ -166,6 +186,45 @@
 		3A1CCF4A14684EFA00E639D4 /* UIViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIViewProcessor.m; sourceTree = "<group>"; };
 		3A1CCF4B14684EFA00E639D4 /* UIWebViewProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIWebViewProcessor.h; sourceTree = "<group>"; };
 		3A1CCF4C14684EFA00E639D4 /* UIWebViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIWebViewProcessor.m; sourceTree = "<group>"; };
+		C36F0D851508F3F600A96F84 /* NSArrayControllerProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSArrayControllerProcessor.h; sourceTree = "<group>"; };
+		C36F0D861508F3F600A96F84 /* NSArrayControllerProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArrayControllerProcessor.m; sourceTree = "<group>"; };
+		C36F0D871508F3F600A96F84 /* NSBoxProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSBoxProcessor.h; sourceTree = "<group>"; };
+		C36F0D881508F3F600A96F84 /* NSBoxProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSBoxProcessor.m; sourceTree = "<group>"; };
+		C36F0D891508F3F600A96F84 /* NSButtonCellProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSButtonCellProcessor.h; sourceTree = "<group>"; };
+		C36F0D8A1508F3F600A96F84 /* NSButtonCellProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSButtonCellProcessor.m; sourceTree = "<group>"; };
+		C36F0D8B1508F3F600A96F84 /* NSButtonProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSButtonProcessor.h; sourceTree = "<group>"; };
+		C36F0D8C1508F3F600A96F84 /* NSButtonProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSButtonProcessor.m; sourceTree = "<group>"; };
+		C36F0D8D1508F3F600A96F84 /* NSCellProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSCellProcessor.h; sourceTree = "<group>"; };
+		C36F0D8E1508F3F600A96F84 /* NSCellProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSCellProcessor.m; sourceTree = "<group>"; };
+		C36F0D8F1508F3F600A96F84 /* NSCollectionViewProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSCollectionViewProcessor.h; sourceTree = "<group>"; };
+		C36F0D901508F3F600A96F84 /* NSCollectionViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSCollectionViewProcessor.m; sourceTree = "<group>"; };
+		C36F0D911508F3F600A96F84 /* NSCustomViewProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSCustomViewProcessor.h; sourceTree = "<group>"; };
+		C36F0D921508F3F600A96F84 /* NSCustomViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSCustomViewProcessor.m; sourceTree = "<group>"; };
+		C36F0D931508F3F600A96F84 /* NSImageCellProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSImageCellProcessor.h; sourceTree = "<group>"; };
+		C36F0D941508F3F600A96F84 /* NSImageCellProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSImageCellProcessor.m; sourceTree = "<group>"; };
+		C36F0D951508F3F600A96F84 /* NSImageViewProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSImageViewProcessor.h; sourceTree = "<group>"; };
+		C36F0D961508F3F600A96F84 /* NSImageViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSImageViewProcessor.m; sourceTree = "<group>"; };
+		C36F0D971508F3F600A96F84 /* NSPopUpButtonCellProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSPopUpButtonCellProcessor.h; sourceTree = "<group>"; };
+		C36F0D981508F3F600A96F84 /* NSPopUpButtonCellProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSPopUpButtonCellProcessor.m; sourceTree = "<group>"; };
+		C36F0D991508F3F600A96F84 /* NSPopUpButtonProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSPopUpButtonProcessor.h; sourceTree = "<group>"; };
+		C36F0D9A1508F3F600A96F84 /* NSPopUpButtonProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSPopUpButtonProcessor.m; sourceTree = "<group>"; };
+		C36F0D9B1508F3F600A96F84 /* NSScrollerProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSScrollerProcessor.h; sourceTree = "<group>"; };
+		C36F0D9C1508F3F600A96F84 /* NSScrollerProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSScrollerProcessor.m; sourceTree = "<group>"; };
+		C36F0D9D1508F3F600A96F84 /* NSScrollViewProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSScrollViewProcessor.h; sourceTree = "<group>"; };
+		C36F0D9E1508F3F600A96F84 /* NSScrollViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSScrollViewProcessor.m; sourceTree = "<group>"; };
+		C36F0D9F1508F3F600A96F84 /* NSSearchFieldCellProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSSearchFieldCellProcessor.h; sourceTree = "<group>"; };
+		C36F0DA01508F3F600A96F84 /* NSSearchFieldCellProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSSearchFieldCellProcessor.m; sourceTree = "<group>"; };
+		C36F0DA11508F3F600A96F84 /* NSSearchFieldProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSSearchFieldProcessor.h; sourceTree = "<group>"; };
+		C36F0DA21508F3F600A96F84 /* NSSearchFieldProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSSearchFieldProcessor.m; sourceTree = "<group>"; };
+		C36F0DA31508F3F600A96F84 /* NSTextFieldCellProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFieldCellProcessor.h; sourceTree = "<group>"; };
+		C36F0DA41508F3F600A96F84 /* NSTextFieldCellProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSTextFieldCellProcessor.m; sourceTree = "<group>"; };
+		C36F0DA51508F3F600A96F84 /* NSTextFieldProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFieldProcessor.h; sourceTree = "<group>"; };
+		C36F0DA61508F3F600A96F84 /* NSTextFieldProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSTextFieldProcessor.m; sourceTree = "<group>"; };
+		C36F0DA71508F3F600A96F84 /* NSViewProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSViewProcessor.h; sourceTree = "<group>"; };
+		C36F0DA81508F3F600A96F84 /* NSViewProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSViewProcessor.m; sourceTree = "<group>"; };
+		C36F0DA91508F3F600A96F84 /* NSWindowTemplateProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSWindowTemplateProcessor.h; sourceTree = "<group>"; };
+		C36F0DAA1508F3F600A96F84 /* NSWindowTemplateProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSWindowTemplateProcessor.m; sourceTree = "<group>"; };
+		C36F0E041508F8BA00A96F84 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A1CCED614684E1200E639D4 /* Foundation.framework in Frameworks */,
+				C36F0E051508F8BA00A96F84 /* AppKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,6 +260,7 @@
 		3A1CCED414684E1200E639D4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C36F0E041508F8BA00A96F84 /* AppKit.framework */,
 				3A1CCED514684E1200E639D4 /* Foundation.framework */,
 			);
 			name = Frameworks;
@@ -251,6 +312,7 @@
 		3A1CCEF814684EFA00E639D4 /* Processors */ = {
 			isa = PBXGroup;
 			children = (
+				C36F0D841508F3F600A96F84 /* AppKit */,
 				3A1CCEF914684EFA00E639D4 /* GLKViewControllerProcessor.h */,
 				3A1CCEFA14684EFA00E639D4 /* GLKViewControllerProcessor.m */,
 				3A1CCEFB14684EFA00E639D4 /* GLKViewProcessor.h */,
@@ -339,6 +401,51 @@
 			path = Processors;
 			sourceTree = "<group>";
 		};
+		C36F0D841508F3F600A96F84 /* AppKit */ = {
+			isa = PBXGroup;
+			children = (
+				C36F0D851508F3F600A96F84 /* NSArrayControllerProcessor.h */,
+				C36F0D861508F3F600A96F84 /* NSArrayControllerProcessor.m */,
+				C36F0D871508F3F600A96F84 /* NSBoxProcessor.h */,
+				C36F0D881508F3F600A96F84 /* NSBoxProcessor.m */,
+				C36F0D891508F3F600A96F84 /* NSButtonCellProcessor.h */,
+				C36F0D8A1508F3F600A96F84 /* NSButtonCellProcessor.m */,
+				C36F0D8B1508F3F600A96F84 /* NSButtonProcessor.h */,
+				C36F0D8C1508F3F600A96F84 /* NSButtonProcessor.m */,
+				C36F0D8D1508F3F600A96F84 /* NSCellProcessor.h */,
+				C36F0D8E1508F3F600A96F84 /* NSCellProcessor.m */,
+				C36F0D8F1508F3F600A96F84 /* NSCollectionViewProcessor.h */,
+				C36F0D901508F3F600A96F84 /* NSCollectionViewProcessor.m */,
+				C36F0D911508F3F600A96F84 /* NSCustomViewProcessor.h */,
+				C36F0D921508F3F600A96F84 /* NSCustomViewProcessor.m */,
+				C36F0D931508F3F600A96F84 /* NSImageCellProcessor.h */,
+				C36F0D941508F3F600A96F84 /* NSImageCellProcessor.m */,
+				C36F0D951508F3F600A96F84 /* NSImageViewProcessor.h */,
+				C36F0D961508F3F600A96F84 /* NSImageViewProcessor.m */,
+				C36F0D971508F3F600A96F84 /* NSPopUpButtonCellProcessor.h */,
+				C36F0D981508F3F600A96F84 /* NSPopUpButtonCellProcessor.m */,
+				C36F0D991508F3F600A96F84 /* NSPopUpButtonProcessor.h */,
+				C36F0D9A1508F3F600A96F84 /* NSPopUpButtonProcessor.m */,
+				C36F0D9B1508F3F600A96F84 /* NSScrollerProcessor.h */,
+				C36F0D9C1508F3F600A96F84 /* NSScrollerProcessor.m */,
+				C36F0D9D1508F3F600A96F84 /* NSScrollViewProcessor.h */,
+				C36F0D9E1508F3F600A96F84 /* NSScrollViewProcessor.m */,
+				C36F0D9F1508F3F600A96F84 /* NSSearchFieldCellProcessor.h */,
+				C36F0DA01508F3F600A96F84 /* NSSearchFieldCellProcessor.m */,
+				C36F0DA11508F3F600A96F84 /* NSSearchFieldProcessor.h */,
+				C36F0DA21508F3F600A96F84 /* NSSearchFieldProcessor.m */,
+				C36F0DA31508F3F600A96F84 /* NSTextFieldCellProcessor.h */,
+				C36F0DA41508F3F600A96F84 /* NSTextFieldCellProcessor.m */,
+				C36F0DA51508F3F600A96F84 /* NSTextFieldProcessor.h */,
+				C36F0DA61508F3F600A96F84 /* NSTextFieldProcessor.m */,
+				C36F0DA71508F3F600A96F84 /* NSViewProcessor.h */,
+				C36F0DA81508F3F600A96F84 /* NSViewProcessor.m */,
+				C36F0DA91508F3F600A96F84 /* NSWindowTemplateProcessor.h */,
+				C36F0DAA1508F3F600A96F84 /* NSWindowTemplateProcessor.m */,
+			);
+			path = AppKit;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -368,8 +475,7 @@
 				LastUpgradeCheck = 0420;
 			};
 			buildConfigurationList = 3A1CCECB14684E1200E639D4 /* Build configuration list for PBXProject "Command Line" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			compatibilityVersion = "Xcode 3.1";
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -436,6 +542,25 @@
 				3A1CCF7814684EFA00E639D4 /* UIViewControllerProcessor.m in Sources */,
 				3A1CCF7914684EFA00E639D4 /* UIViewProcessor.m in Sources */,
 				3A1CCF7A14684EFA00E639D4 /* UIWebViewProcessor.m in Sources */,
+				C36F0DAB1508F3F600A96F84 /* NSArrayControllerProcessor.m in Sources */,
+				C36F0DAC1508F3F600A96F84 /* NSBoxProcessor.m in Sources */,
+				C36F0DAD1508F3F600A96F84 /* NSButtonCellProcessor.m in Sources */,
+				C36F0DAE1508F3F600A96F84 /* NSButtonProcessor.m in Sources */,
+				C36F0DAF1508F3F600A96F84 /* NSCellProcessor.m in Sources */,
+				C36F0DB01508F3F600A96F84 /* NSCollectionViewProcessor.m in Sources */,
+				C36F0DB11508F3F600A96F84 /* NSCustomViewProcessor.m in Sources */,
+				C36F0DB21508F3F600A96F84 /* NSImageCellProcessor.m in Sources */,
+				C36F0DB31508F3F600A96F84 /* NSImageViewProcessor.m in Sources */,
+				C36F0DB41508F3F600A96F84 /* NSPopUpButtonCellProcessor.m in Sources */,
+				C36F0DB51508F3F600A96F84 /* NSPopUpButtonProcessor.m in Sources */,
+				C36F0DB61508F3F600A96F84 /* NSScrollerProcessor.m in Sources */,
+				C36F0DB71508F3F600A96F84 /* NSScrollViewProcessor.m in Sources */,
+				C36F0DB81508F3F600A96F84 /* NSSearchFieldCellProcessor.m in Sources */,
+				C36F0DB91508F3F600A96F84 /* NSSearchFieldProcessor.m in Sources */,
+				C36F0DBA1508F3F600A96F84 /* NSTextFieldCellProcessor.m in Sources */,
+				C36F0DBB1508F3F600A96F84 /* NSTextFieldProcessor.m in Sources */,
+				C36F0DBC1508F3F600A96F84 /* NSViewProcessor.m in Sources */,
+				C36F0DBD1508F3F600A96F84 /* NSWindowTemplateProcessor.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -457,14 +582,14 @@
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.5;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
+				SDKROOT = "";
 			};
 			name = Debug;
 		};
@@ -477,13 +602,13 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				SDKROOT = macosx;
+				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				SDKROOT = "";
 			};
 			name = Release;
 		};

--- a/Command Line/nib2objc/main.m
+++ b/Command Line/nib2objc/main.m
@@ -25,9 +25,8 @@ int main (int argc, const char * argv[])
 	// Test that the input file exists, and that it is not a directory
 	NSString *nibFile = [NSString stringWithCString:argv[1] encoding:NSUTF8StringEncoding];
 	NSFileManager *manager = [NSFileManager defaultManager];
-	BOOL isDirectory = NO;
-	BOOL fileExists = [manager fileExistsAtPath:nibFile isDirectory:&isDirectory];
-	if (!fileExists || isDirectory)
+	BOOL fileExists = [manager fileExistsAtPath:nibFile];
+	if (!fileExists)
 	{
 		printf("This utility requires a valid NIB file path as parameter.\n");
 		return 0;

--- a/Command Line/nib2objc/main.m
+++ b/Command Line/nib2objc/main.m
@@ -12,50 +12,50 @@
 
 int main (int argc, const char * argv[])
 {
-
-    @autoreleasepool {
-        
-        // Verify that we have the required number of parameters in the command line
-        if (argc < 2)
-        {
-            printf("This utility requires a valid NIB file path as parameter.\n");
-            return 0;
-        }
-        
-        // Test that the input file exists, and that it is not a directory
-        NSString *nibFile = [NSString stringWithCString:argv[1] encoding:NSUTF8StringEncoding];
-        NSFileManager *manager = [NSFileManager defaultManager];
-        BOOL isDirectory = NO;
-        BOOL fileExists = [manager fileExistsAtPath:nibFile isDirectory:&isDirectory];
-        if (!fileExists || isDirectory)
-        {
-            printf("This utility requires a valid NIB file path as parameter.\n");
-            return 0;
-        }
-        
-        // As an optional second parameter, specify whether to use properties or setters
-        NibProcessorCodeStyle codeStyle = NibProcessorCodeStyleProperties;
-        
-        if (argc > 2)
-        {
-            int value = atoi(argv[2]);
-            
-            if (value == 1 || value == 2)
-            {
-                codeStyle = (NibProcessorCodeStyle)value;
-            }
-        }
-        
-        // Use a Processor instance to generate the source code file 
-        // and redirect the output to the standard output stream
-        NibProcessor *processor = [[NibProcessor alloc] init];
-        processor.codeStyle = codeStyle;
-        processor.input = nibFile;
-        [processor process];
-        printf([processor.output UTF8String], NULL);
-        [processor release];
-        
-    }
+	
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+	
+	// Verify that we have the required number of parameters in the command line
+	if (argc < 2)
+	{
+		printf("This utility requires a valid NIB file path as parameter.\n");
+		return 0;
+	}
+	
+	// Test that the input file exists, and that it is not a directory
+	NSString *nibFile = [NSString stringWithCString:argv[1] encoding:NSUTF8StringEncoding];
+	NSFileManager *manager = [NSFileManager defaultManager];
+	BOOL isDirectory = NO;
+	BOOL fileExists = [manager fileExistsAtPath:nibFile isDirectory:&isDirectory];
+	if (!fileExists || isDirectory)
+	{
+		printf("This utility requires a valid NIB file path as parameter.\n");
+		return 0;
+	}
+	
+	// As an optional second parameter, specify whether to use properties or setters
+	NibProcessorCodeStyle codeStyle = NibProcessorCodeStyleProperties;
+	
+	if (argc > 2)
+	{
+		int value = atoi(argv[2]);
+		
+		if (value == 1 || value == 2)
+		{
+			codeStyle = (NibProcessorCodeStyle)value;
+		}
+	}
+	
+	// Use a Processor instance to generate the source code file 
+	// and redirect the output to the standard output stream
+	NibProcessor *processor = [[NibProcessor alloc] init];
+	processor.codeStyle = codeStyle;
+	processor.input = nibFile;
+	[processor process];
+	printf([processor.output UTF8String], NULL);
+	[processor release];
+	
+    [pool drain];
     return 0;
 }
 

--- a/NibProcessor/NibProcessor.m
+++ b/NibProcessor/NibProcessor.m
@@ -125,7 +125,7 @@
 
         if (processor == nil)
         {
-#ifdef CONFIGURATION_Debug
+#ifdef DEBUG
             // Get notified about classes not yet handled by this utility
             NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
             [dict setObject:klass forKey:@"// unknown object (yet)"];

--- a/NibProcessor/Processors/AppKit/NSArrayControllerProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSArrayControllerProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSArrayControllerProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSArrayControllerProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSArrayControllerProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSArrayControllerProcessor.m
@@ -1,0 +1,96 @@
+//
+//  NSArrayControllerProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSArrayControllerProcessor.h"
+
+@implementation NSArrayControllerProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSArrayController";
+}
+
+- (NSString *)constructorString
+{
+	NSString *className = [self getProcessedClassName];
+	return [NSString stringWithFormat:@"[[[%@ alloc] init] autorelease]", className];
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"alwaysUsesMultipleValuesMarkerDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"alwaysUsesMultipleValuesMarker";
+	}
+	else if ([item isEqualToString:@"automaticallyPreparesContentDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"automaticallyPreparesContent";
+	}
+	else if ([item isEqualToString:@"automaticallyRearrangesObjectsDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"automaticallyRearrangesObjects";
+	}
+	else if ([item isEqualToString:@"avoidsEmptySelectionDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"avoidsEmptySelection";
+	}
+	else if ([item isEqualToString:@"clearsFilterPredicateOnInsertionDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"clearsFilterPredicateOnInsertion";
+	}
+	else if ([item isEqualToString:@"editableDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"editable";
+	}
+	else if ([item isEqualToString:@"objectClassNameDesignable"])
+	{
+		aString = [NSString stringWithFormat:@"NSClassFromString(@\"%@\")", value];
+		item = @"objectClass";
+	}
+	else if ([item isEqualToString:@"preservesSelectionDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"preservesSelection";
+	}
+	else if ([item isEqualToString:@"selectsInsertedObjectsDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"selectsInsertedObjects";
+	}
+	else if ([item isEqualToString:@"usesLazyFetchingDesignable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+		item = @"usesLazyFetching";
+	}
+	else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSBoxProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSBoxProcessor.h
@@ -1,0 +1,16 @@
+//
+//  NSBoxProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSBoxProcessor : NSViewProcessor
+
+- (NSString *)boxTypeString:(id)value;
+- (NSString *)titlePositionString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSBoxProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSBoxProcessor.m
@@ -1,0 +1,110 @@
+//
+//  NSBoxProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSBoxProcessor.h"
+
+@implementation NSBoxProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSBox";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"borderColor"])
+	{
+		aString = [self colorString:value];
+	}
+	else if ([item isEqualToString:@"borderType"])
+    {
+        aString = [self borderTypeString:value];
+    }
+    else if ([item isEqualToString:@"borderWidth"])
+    {
+        aString = [self floatString:value];
+    }
+	else if ([item isEqualToString:@"boxType"])
+    {
+		aString = [self boxTypeString:value];
+    }
+	else if ([item isEqualToString:@"contentViewMargins"])
+    {
+        aString = [self sizeString:value];
+    }
+	else if ([item isEqualToString:@"cornerRadius"])
+    {
+        aString = [self floatString:value];
+    }
+	else if ([item isEqualToString:@"fillColor"])
+    {
+        aString = [self colorString:value];
+    }
+	else if ([item isEqualToString:@"title"])
+    {
+        aString = [NSString stringWithFormat:@"@\"%@\"", value];
+	}
+	else if ([item isEqualToString:@"titleFont"])
+    {
+		aString = [self fontString:value];
+	}
+	else if ([item isEqualToString:@"titlePosition"])
+    {
+		aString = [self titlePositionString:value];
+    }
+	else if ([item isEqualToString:@"transparent"])
+    {
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+    else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)boxTypeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSBoxPrimary",
+                       @"NSBoxSecondary",
+                       @"NSBoxSeparator",
+					   @"NSBoxOldStyle",
+					   @"NSBoxCustom", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)titlePositionString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSNoTitle",
+					   @"NSAboveTop",
+					   @"NSAtTop",
+					   @"NSBelowTop",
+					   @"NSAboveBottom",
+					   @"NSAtBottom",
+					   @"NSBelowBottom", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSButtonCellProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSButtonCellProcessor.h
@@ -1,0 +1,18 @@
+//
+//  NSButtonCellProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSCellProcessor.h"
+
+@interface NSButtonCellProcessor : NSCellProcessor
+
+- (NSString *)bezelStyleString:(id)value;
+- (NSString *)buttonTypeString:(id)value;
+- (NSString *)imagePositionString:(id)value;
+- (NSString *)keyEquivalentModifierMaskString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSButtonCellProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSButtonCellProcessor.m
@@ -1,0 +1,266 @@
+//
+//  NSButtonCellProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSButtonCellProcessor.h"
+
+@implementation NSButtonCellProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSButtonCell";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"allowsMixedState"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"alternateTitle"])
+    {
+        aString = [NSString stringWithFormat:@"@\"%@\"", value];
+    }
+	else if ([item isEqualToString:@"bezelStyle"])
+    {
+        aString = [self bezelStyleString:value];
+    }
+	else if ([item isEqualToString:@"font"])
+    {
+        aString = [self fontString:value];
+    }
+	else if ([item isEqualToString:@"gButtonBehavior"])
+	{
+		int intValue = [value intValue];
+		if (intValue == 6)
+		{
+			value = [NSNumber numberWithUnsignedInteger:0];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+		else if (intValue == 7)
+		{
+			value = [NSNumber numberWithUnsignedInteger:7];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+		else if (intValue == 30)
+		{
+			value = [NSNumber numberWithUnsignedInteger:6];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+		else if (intValue == 31)
+		{
+			value = [NSNumber numberWithUnsignedInteger:1];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+		else if (intValue == 128)
+		{
+			value = [NSNumber numberWithUnsignedInteger:5];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+		else if (intValue == 161)
+		{
+			value = [NSNumber numberWithUnsignedInteger:2];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+		else if (intValue == 224)
+		{
+			value = [NSNumber numberWithUnsignedInteger:3];
+			aString = [self buttonTypeString:value];
+			item = @"buttonType";
+		}
+	}
+	else if ([item isEqualToString:@"ibImagePosition"])
+    {
+        aString = [self imagePositionString:value];
+		item = @"imagePosition";
+    }
+	else if ([item isEqualToString:@"imageScaling"])
+    {
+        aString = [self imageScalingString:value];
+    }
+	else if ([item isEqualToString:@"keyEquivalentModifierMask"])
+    {
+        aString = [self keyEquivalentModifierMaskString:value];
+    }
+	else if ([item isEqualToString:@"transparent"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+    else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)bezelStyleString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSSmallIconButtonBezelStyle",
+					   @"NSRoundedBezelStyle",
+                       @"NSRegularSquareBezelStyle",
+                       @"NSThickSquareBezelStyle",
+					   @"NSThickerSquareBezelStyle",
+					   @"NSDisclosureBezelStyle",
+					   @"NSShadowlessSquareBezelStyle",
+					   @"NSCircularBezelStyle",
+					   @"NSTexturedSquareBezelStyle",
+					   @"NSHelpButtonBezelStyle",
+					   @"NSSmallSquareBezelStyle",
+					   @"NSTexturedRoundedBezelStyle",
+					   @"NSRoundRectBezelStyle",
+					   @"NSRecessedBezelStyle",
+					   @"NSRoundedDisclosureBezelStyle", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)buttonTypeString:(id)value
+{
+	/* From the documentation
+	 enum {
+	 NSMomentaryLightButton = 0,
+	 NSPushOnPushOffButton = 1,
+	 NSToggleButton = 2,
+	 NSSwitchButton = 3,
+	 NSMomentaryChangeButton = 5,
+	 NSOnOffButton = 6,
+	 NSMomentaryPushInButton = 7
+	 };
+	 */
+	
+	NSString *aString = nil;
+	NSUInteger unsignedIntegerValue = [value unsignedIntegerValue];
+	if (unsignedIntegerValue == NSMomentaryLightButton)
+    {
+        aString = @"NSMomentaryLightButton";
+    }
+    else if (unsignedIntegerValue == NSMomentaryPushInButton)
+    {
+        aString = @"NSMomentaryPushInButton";
+    }
+    else if (unsignedIntegerValue == NSOnOffButton)
+    {
+		aString = @"NSOnOffButton";
+    }
+	else if (unsignedIntegerValue == NSPushOnPushOffButton)
+    {
+		[output setObject:@"YES" forKey:@"showsBorderOnlyWhileMouseInside"];
+		aString = @"NSPushOnPushOffButton";
+    }
+	else if (unsignedIntegerValue == NSMomentaryChangeButton)
+    {
+		aString = @"NSMomentaryChangeButton";
+    }
+	else if (unsignedIntegerValue == NSToggleButton)
+    {
+		aString = @"NSToggleButton";
+    }
+	else if (unsignedIntegerValue == NSSwitchButton)
+    {
+		aString = @"NSSwitchButton";
+    }
+	return aString;
+}
+
+- (NSString *)imagePositionString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSNoImage",
+                       @"NSImageOnly",
+                       @"NSImageLeft",
+					   @"NSImageRight",
+					   @"NSImageBelow",
+					   @"NSImageAbove",
+					   @"NSImageOverlaps", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)keyEquivalentModifierMaskString:(id)value
+{
+    /* From the documentation
+	 enum 
+	 {
+	 NSAlphaShiftKeyMask = 1 << 16,
+	 NSShiftKeyMask = 1 << 17,
+	 NSControlKeyMask = 1 << 18,
+	 NSAlternateKeyMask = 1 << 19,
+	 NSCommandKeyMask = 1 << 20,
+	 NSNumericPadKeyMask = 1 << 21,
+	 NSHelpKeyMask = 1 << 22,
+	 NSFunctionKeyMask = 1 << 23
+	 };
+	 */
+    
+    NSUInteger mask = [value unsignedIntegerValue];
+    NSMutableString *maskValue = [[[NSMutableString alloc] init] autorelease];
+    
+    if ((mask & NSAlphaShiftKeyMask) == NSAlphaShiftKeyMask)
+    {
+        [maskValue appendString:@"NSAlphaShiftKeyMask"];
+    }
+    if ((mask & NSShiftKeyMask) == NSShiftKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSShiftKeyMask"];
+    }
+    if ((mask & NSControlKeyMask) == NSControlKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSControlKeyMask"];
+    }
+    if ((mask & NSAlternateKeyMask) == NSAlternateKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSAlternateKeyMask"];
+    }
+	if ((mask & NSCommandKeyMask) == NSCommandKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSCommandKeyMask"];
+    }
+	if ((mask & NSNumericPadKeyMask) == NSNumericPadKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSNumericPadKeyMask"];
+    }
+	if ((mask & NSHelpKeyMask) == NSHelpKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSHelpKeyMask"];
+    }
+	if ((mask & NSFunctionKeyMask) == NSFunctionKeyMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSFunctionKeyMask"];
+    }
+	if ([maskValue length] == 0) [maskValue appendString:@"0"];
+    
+    return maskValue;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSButtonProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSButtonProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSButtonProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSButtonProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSButtonProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSButtonProcessor.m
@@ -1,0 +1,23 @@
+//
+//  NSButtonProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSButtonProcessor.h"
+
+@implementation NSButtonProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSButton";
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSCellProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSCellProcessor.h
@@ -1,0 +1,20 @@
+//
+//  NSCellProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSCellProcessor : NSViewProcessor
+
+- (NSString *)alignmentString:(id)value;
+- (NSString *)baseWritingDirectionString:(id)value;
+- (NSString *)controlSizeString:(id)value;
+- (NSString *)imageScalingString:(id)value;
+- (NSString *)lineBreakModeString:(id)value;
+- (NSString *)stateString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSCellProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSCellProcessor.m
@@ -1,0 +1,205 @@
+//
+//  NSCellProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSCellProcessor.h"
+
+@implementation NSCellProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSCell";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"class"])
+    {
+        aString = [self getProcessedClassName];
+    }
+	else if ([item isEqualToString:@"alignment"])
+	{
+		aString = [self alignmentString:value];
+	}
+	else if ([item isEqualToString:@"animates"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"baseWritingDirection"])
+	{
+		aString = [self baseWritingDirectionString:value];
+	}
+	else if ([item isEqualToString:@"bordered"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"continuous"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"controlSize"])
+	{
+		aString = [self controlSizeString:value];
+	}
+	else if ([item isEqualToString:@"editable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"enabled"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"lineBreakMode"])
+	{
+		aString = [self lineBreakModeString:value];
+	}
+	else if ([item isEqualToString:@"scrollable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"selectable"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"sendsActionOnEndEditing"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"state"])
+	{
+		aString = [self stateString:value];
+	}
+	else if ([item isEqualToString:@"title"])
+	{
+		aString = [NSString stringWithFormat:@"@\"%@\"", value];
+	}
+	else if ([item isEqualToString:@"truncatesLastVisibleLine"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)alignmentString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSLeftTextAlignment",
+                       @"NSRightTextAlignment",
+                       @"NSCenterTextAlignment",
+					   @"NSJustifiedTextAlignment",
+					   @"NSNaturalTextAlignment", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)baseWritingDirectionString:(id)value
+{
+	/* From the documentation
+	 enum 
+	 {
+	 NSWritingDirectionNatural = -1,
+	 NSWritingDirectionLeftToRight = 0,
+	 NSWritingDirectionRightToLeft = 1
+	 };
+	 */
+	
+	NSString *aString = nil;
+	NSInteger integerValue = [value integerValue];
+	if (integerValue == NSWritingDirectionNatural)
+    {
+        aString = @"NSWritingDirectionNatural";
+    }
+    else if (integerValue == NSWritingDirectionLeftToRight)
+    {
+        aString = @"NSWritingDirectionLeftToRight";
+    }
+    else if (integerValue == NSWritingDirectionRightToLeft)
+    {
+		aString = @"NSWritingDirectionRightToLeft";
+    }
+	return aString;
+}
+
+- (NSString *)controlSizeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSRegularControlSize",
+                       @"NSSmallControlSize",
+                       @"NSMiniControlSize", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)imageScalingString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSImageScaleProportionallyDown",
+                       @"NSImageScaleAxesIndependently",
+                       @"NSImageScaleNone",
+					   @"NSImageScaleProportionallyUpOrDown", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)lineBreakModeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSLineBreakByWordWrapping",
+                       @"NSLineBreakByCharWrapping",
+                       @"NSLineBreakByClipping",
+					   @"NSLineBreakByTruncatingHead",
+					   @"NSLineBreakByTruncatingTail",
+					   @"NSLineBreakByTruncatingMiddle", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)stateString:(id)value
+{
+	/* From the documentation
+	 enum {
+	 NSMixedState = -1,
+	 NSOffState = 0,
+	 NSOnState = 1    
+	 };
+	 */
+	
+	NSString *aString = nil;
+	NSInteger integerValue = [value integerValue];
+	if (integerValue == NSMixedState)
+    {
+        aString = @"NSMixedState";
+    }
+    else if (integerValue == NSOffState)
+    {
+        aString = @"NSOffState";
+    }
+    else if (integerValue == NSOnState)
+    {
+		aString = @"NSOnState";
+    }
+	return aString;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSCollectionViewProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSCollectionViewProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSCollectionViewProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSCollectionViewProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSCollectionViewProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSCollectionViewProcessor.m
@@ -1,0 +1,73 @@
+//
+//  NSCollectionViewProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSCollectionViewProcessor.h"
+
+@implementation NSCollectionViewProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSCollectionView";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+    if ([item isEqualToString:@"allowsMultipleSelection"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+    else if ([item isEqualToString:@"maxNumberOfColumns"])
+    {
+        aString = [NSString stringWithFormat:@"%@", value];
+    }
+	else if ([item isEqualToString:@"maxNumberOfRows"])
+    {
+        aString = [NSString stringWithFormat:@"%@", value];
+    }
+	else if ([item isEqualToString:@"hasSecondaryBackgroundColor"])
+    {
+		if ([value boolValue])
+		{
+			aString = [self colorString:value];
+			item = @"backgroundColors";
+		}
+    }
+	else if ([item isEqualToString:@"selectable"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+    else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)colorString:(id)value
+{
+	NSString *aString = nil;
+	NSString *primaryBackgroundColor = [super colorString:[self.input objectForKey:@"primaryBackgroundColor"]];
+	NSString *secondaryBackgroundColor = [super colorString:[self.input objectForKey:@"secondaryBackgroundColor"]];
+	aString = [NSString stringWithFormat:@"[NSArray arrayWithObjects:%@, %@, nil]", primaryBackgroundColor, secondaryBackgroundColor];
+	return aString;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSCustomViewProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSCustomViewProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSCustomViewProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSCustomViewProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSCustomViewProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSCustomViewProcessor.m
@@ -1,0 +1,23 @@
+//
+//  NSCustomViewProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSCustomViewProcessor.h"
+
+@implementation NSCustomViewProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)constructorString
+{
+	return [NSString stringWithFormat:@"[[[%@ alloc] initWithFrame:%@] autorelease]", [self.input objectForKey:@"className"], [self frameString]];
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSImageCellProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSImageCellProcessor.h
@@ -1,0 +1,16 @@
+//
+//  NSImageCellProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSCellProcessor.h"
+
+@interface NSImageCellProcessor : NSCellProcessor
+
+- (NSString *)imageAlignmentString:(id)value;
+- (NSString *)imageFrameStyleString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSImageCellProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSImageCellProcessor.m
@@ -1,0 +1,80 @@
+//
+//  NSImageCellProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSImageCellProcessor.h"
+
+@implementation NSImageCellProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSImageCell";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"imageAlignment"])
+	{
+		aString = [self imageAlignmentString:value];
+	}
+	else if ([item isEqualToString:@"imageFrameStyle"])
+	{
+		aString = [self imageFrameStyleString:value];
+	}
+	else if ([item isEqualToString:@"imageScaling"])
+	{
+		aString = [self imageScalingString:value];
+	}
+	else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)imageAlignmentString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSImageAlignCenter",
+                       @"NSImageAlignTop",
+                       @"NSImageAlignTopLeft",
+					   @"NSImageAlignTopRight",
+					   @"NSImageAlignLeft",
+					   @"NSImageAlignBottom",
+					   @"NSImageAlignBottomLeft",
+					   @"NSImageAlignBottomRight",
+					   @"NSImageAlignRight", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)imageFrameStyleString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSImageFrameNone",
+                       @"NSImageFramePhoto",
+                       @"NSImageFrameGrayBezel",
+					   @"NSImageFrameGroove",
+					   @"NSImageFrameButton", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSImageViewProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSImageViewProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSImageViewProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSImageViewProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSImageViewProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSImageViewProcessor.m
@@ -1,0 +1,23 @@
+//
+//  NSImageViewProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSImageViewProcessor.h"
+
+@implementation NSImageViewProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSImageView";
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSPopUpButtonCellProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSPopUpButtonCellProcessor.h
@@ -1,0 +1,16 @@
+//
+//  NSPopUpButtonCellProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSButtonCellProcessor.h"
+
+@interface NSPopUpButtonCellProcessor : NSButtonCellProcessor
+
+- (NSString *)arrowPositionString:(id)value;
+- (NSString *)preferredEdgeString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSPopUpButtonCellProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSPopUpButtonCellProcessor.m
@@ -1,0 +1,73 @@
+//
+//  NSPopUpButtonCellProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSPopUpButtonCellProcessor.h"
+
+@implementation NSPopUpButtonCellProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSPopUpButtonCell";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"arrowPosition"])
+	{
+		aString = [self arrowPositionString:value];
+	}
+	else if ([item isEqualToString:@"preferredEdge"])
+	{
+		aString = [self preferredEdgeString:value];
+	}
+	else if ([item isEqualToString:@"pullsDown"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)arrowPositionString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSPopUpNoArrow",
+                       @"NSPopUpArrowAtCenter",
+                       @"NSPopUpArrowAtBottom", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)preferredEdgeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSMinXEdge",
+                       @"NSMinYEdge",
+                       @"NSMaxXEdge",
+					   @"NSMaxYEdge", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSPopUpButtonProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSPopUpButtonProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSPopUpButtonProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSButtonProcessor.h"
+
+@interface NSPopUpButtonProcessor : NSButtonProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSPopUpButtonProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSPopUpButtonProcessor.m
@@ -1,0 +1,23 @@
+//
+//  NSPopUpButtonProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSPopUpButtonProcessor.h"
+
+@implementation NSPopUpButtonProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSPopUpButton";
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSScrollViewProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSScrollViewProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSScrollViewProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSScrollViewProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSScrollViewProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSScrollViewProcessor.m
@@ -1,0 +1,92 @@
+//
+//  NSScrollViewProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSScrollViewProcessor.h"
+
+@implementation NSScrollViewProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSScrollView";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+    if ([item isEqualToString:@"autohidesScrollers"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"backgroundColor"])
+    {
+        aString = [self colorString:value];
+    }
+    else if ([item isEqualToString:@"borderType"])
+    {
+        aString = [self borderTypeString:value];
+    }
+	else if ([item isEqualToString:@"contentView.copiesOnScroll"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"drawsBackground"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"hasHorizontalRuler"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"hasHorizontalScroller"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"hasVerticalRuler"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"hasVerticalScroller"])
+    {
+        aString = ([value boolValue]) ? @"YES" : @"NO";
+    }
+	else if ([item isEqualToString:@"horizontalLineScroll"])
+    {
+        aString = [self floatString:value];
+    }
+	else if ([item isEqualToString:@"horizontalPageScroll"])
+    {
+        aString = [self floatString:value];
+    }
+	else if ([item isEqualToString:@"verticalLineScroll"])
+    {
+        aString = [self floatString:value];
+    }
+	else if ([item isEqualToString:@"verticalPageScroll"])
+    {
+        aString = [self floatString:value];
+    }
+    else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSScrollerProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSScrollerProcessor.h
@@ -1,0 +1,15 @@
+//
+//  NSScrollerProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSScrollerProcessor : NSViewProcessor
+
+- (NSString *)arrowPositionString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSScrollerProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSScrollerProcessor.m
@@ -1,0 +1,54 @@
+//
+//  NSScrollerProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSScrollerProcessor.h"
+
+@implementation NSScrollerProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSScroller";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+    if ([item isEqualToString:@"arrowsPosition"])
+    {
+		aString = [self arrowPositionString:value];
+	}
+    else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)arrowPositionString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSScrollerArrowsDefaultSetting",
+					   @"NSScrollerArrowsMinEnd",
+					   @"NSScrollerArrowsNone", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSSearchFieldCellProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSSearchFieldCellProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSSearchFieldCellProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSTextFieldCellProcessor.h"
+
+@interface NSSearchFieldCellProcessor : NSTextFieldCellProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSSearchFieldCellProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSSearchFieldCellProcessor.m
@@ -1,0 +1,52 @@
+//
+//  NSSearchFieldCellProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSSearchFieldCellProcessor.h"
+
+@implementation NSSearchFieldCellProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSSearchFieldCell";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"maximumRecents"])
+	{
+		aString = [NSString stringWithFormat:@"%@", value];
+	}
+	else if ([item isEqualToString:@"sendsSearchStringImmediately"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"sendsWholeSearchString"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSSearchFieldProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSSearchFieldProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSSearchFieldProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSSearchFieldProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSSearchFieldProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSSearchFieldProcessor.m
@@ -1,0 +1,23 @@
+//
+//  NSSearchFieldProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSSearchFieldProcessor.h"
+
+@implementation NSSearchFieldProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSSearchField";
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSTextFieldCellProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSTextFieldCellProcessor.h
@@ -1,0 +1,15 @@
+//
+//  NSTextFieldCellProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSCellProcessor.h"
+
+@interface NSTextFieldCellProcessor : NSCellProcessor
+
+- (NSString *)bezelStyleString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSTextFieldCellProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSTextFieldCellProcessor.m
@@ -1,0 +1,103 @@
+//
+//  NSTextFieldCellProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSTextFieldCellProcessor.h"
+
+@implementation NSTextFieldCellProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSTextFieldCell";
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"allowsEditingTextAttributes"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"backgroundColor"])
+	{
+		aString = [self colorString:value];
+	}
+	else if ([item isEqualToString:@"drawsBackground"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"font"])
+	{
+		aString = [self fontString:value];
+	}
+	else if ([item isEqualToString:@"gBorderType"])
+	{
+		int intValue = [value intValue];
+		if (intValue == 0)
+		{
+			aString = @"NO";
+			item = @"bezeled";
+		}
+		else if (intValue == 2)
+		{
+			value = [NSNumber numberWithUnsignedInteger:0];
+			aString = [self bezelStyleString:value];
+			item = @"bezelStyle";
+		}
+		else if (intValue == 3)
+		{
+			value = [NSNumber numberWithUnsignedInteger:1];
+			aString = [self bezelStyleString:value];
+			item = @"bezelStyle";
+		}
+	}
+	else if ([item isEqualToString:@"textColor"])
+	{
+		aString = [self colorString:value];
+	}
+	else
+    {
+        [super processKey:item value:value];
+    }
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)bezelStyleString:(id)value
+{
+	/* From the documentation
+	enum {
+		NSTextFieldSquareBezel = 0,
+		NSTextFieldRoundedBezel = 1
+	};
+	 */
+	
+	NSString *aString = nil;
+	NSUInteger unsignedIntegerValue = [value unsignedIntegerValue];
+	if (unsignedIntegerValue == NSTextFieldSquareBezel)
+	{
+		aString = @"NSTextFieldSquareBezel";
+	}
+	else if (unsignedIntegerValue == NSTextFieldRoundedBezel)
+	{
+		aString = @"NSTextFieldRoundedBezel";
+	}
+	return aString;
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSTextFieldProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSTextFieldProcessor.h
@@ -1,0 +1,13 @@
+//
+//  NSTextFieldProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@interface NSTextFieldProcessor : NSViewProcessor
+
+@end

--- a/NibProcessor/Processors/AppKit/NSTextFieldProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSTextFieldProcessor.m
@@ -1,0 +1,23 @@
+//
+//  NSTextFieldProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSTextFieldProcessor.h"
+
+@implementation NSTextFieldProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSTextField";
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSViewProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSViewProcessor.h
@@ -1,0 +1,23 @@
+//
+//  NSViewProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "Processor.h"
+
+@interface NSViewProcessor : Processor
+
+- (NSString *)autoresizingMaskString:(id)value;
+- (NSString *)borderTypeString:(id)value;
+- (NSString *)colorString:(id)value;
+- (NSString *)floatString:(id)value;
+- (NSString *)focusRingTypeString:(id)value;
+- (NSString *)fontString:(id)value;
+- (NSString *)sizeString:(id)value;
+
+- (NSString *)checkString:(NSString *)aString key:(id)item value:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSViewProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSViewProcessor.m
@@ -143,7 +143,7 @@
 					{
 						if ([value isEqualToString:anObject])
 						{
-#ifdef CONFIGURATION_Debug
+#ifdef DEBUG
 							aString = [NSString stringWithFormat:@"// default: %@", aString];
 #else
 							aString = nil;
@@ -152,7 +152,7 @@
 					}
 					else if (value == anObject)
 					{
-#ifdef CONFIGURATION_Debug
+#ifdef DEBUG
 						aString = [NSString stringWithFormat:@"// default: %@", aString];
 #else
 						aString = nil;

--- a/NibProcessor/Processors/AppKit/NSViewProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSViewProcessor.m
@@ -1,0 +1,298 @@
+//
+//  NSViewProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSViewProcessor.h"
+
+@implementation NSViewProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSView";
+}
+
+- (NSString *)frameString
+{
+	NSPoint point = NSPointFromString([self.input objectForKey:@"frameOrigin"]);
+	NSSize size = NSSizeFromString([self.input objectForKey:@"frameSize"]);
+	return [NSString stringWithFormat:@"NSMakeRect((CGFloat)%1.1f, (CGFloat)%1.1f, (CGFloat)%1.1f, (CGFloat)%1.1f)", point.x, point.y, size.width, size.height];
+}
+
+- (NSString *)constructorString
+{
+	return [NSString stringWithFormat:@"[[[%@ alloc] initWithFrame:%@] autorelease]", [self getProcessedClassName], [self frameString]];
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"class"])
+    {
+        aString = [self getProcessedClassName];
+    }
+	else if ([item isEqualToString:@"autoresizesSubviews"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"autoresizingMask"])
+	{
+		aString = [self autoresizingMaskString:value];
+	}
+	else if ([item isEqualToString:@"focusRingType"])
+	{
+		aString = [self focusRingTypeString:value];
+	}
+	else if ([item isEqualToString:@"hidden"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"tag"])
+	{
+		aString = [NSString stringWithFormat:@"%@", value];
+	}
+	else if ([item isEqualToString:@"wantsLayer"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	if (aString != nil)
+    {
+        aString = [self checkString:aString key:item value:value];
+    }
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)checkString:(NSString *)aString key:(id)item value:(id)value
+{
+	id object = nil;
+	
+	NSString *aClassName = [self getProcessedClassName];
+	
+	if ([aClassName hasSuffix:@"Cell"])
+	{
+		if ([aClassName isEqualToString:@"NSImageCell"])
+		{
+			Class aClass = NSClassFromString(@"NSImageView");
+			
+			if (aClass)
+			{
+				object = [[[[aClass alloc] initWithFrame:NSZeroRect] autorelease] cell];
+			}
+		}
+		else
+		{
+			Class aClass = NSClassFromString([aClassName substringToIndex:[aClassName length] - [@"Cell" length]]);
+			
+			if (aClass)
+			{
+				object = [[[[aClass alloc] initWithFrame:NSZeroRect] autorelease] cell];
+			}
+		}
+	}
+	else if ([aClassName isEqualToString:@"NSArrayController"])
+	{
+		Class aClass = NSClassFromString(@"NSArrayController");
+		
+		if (aClass)
+		{
+			object = [[[aClass alloc] init] autorelease];
+		}
+	}
+	else
+	{
+		Class aClass = NSClassFromString(aClassName);
+		
+		if (aClass)
+		{
+			object = [[[aClass alloc] initWithFrame:NSZeroRect] autorelease];
+		}
+	}
+	
+	if (object)
+	{
+		SEL selector = NSSelectorFromString(item);
+		
+		BOOL flag = [object respondsToSelector:selector];
+		
+		if (!flag)
+		{
+			selector = NSSelectorFromString([NSString stringWithFormat:@"%@%@", @"is", [item stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:[[item substringToIndex:1] uppercaseString]]]);
+			flag = [object respondsToSelector:selector];
+		}
+		
+		if (flag)
+		{
+			id anObject = [object valueForKey:item];
+			
+			if (anObject)
+			{
+				if (CFGetTypeID(value) == CFGetTypeID(anObject))
+				{
+					if (CFGetTypeID(value) == CFStringGetTypeID())
+					{
+						if ([value isEqualToString:anObject])
+						{
+#ifdef CONFIGURATION_Debug
+							aString = [NSString stringWithFormat:@"// default: %@", aString];
+#else
+							aString = nil;
+#endif
+						}
+					}
+					else if (value == anObject)
+					{
+#ifdef CONFIGURATION_Debug
+						aString = [NSString stringWithFormat:@"// default: %@", aString];
+#else
+						aString = nil;
+#endif
+					}
+				}
+			}
+		}
+	}
+	
+	return aString;
+}
+
+- (NSString *)autoresizingMaskString:(id)value
+{
+	/* From the documentation
+    enum 
+    {
+		NSViewNotSizable = 0,
+		NSViewMinXMargin = 1,
+		NSViewWidthSizable = 2,
+		NSViewMaxXMargin = 4,
+		NSViewMinYMargin = 8,
+		NSViewHeightSizable = 16,
+		NSViewMaxYMargin = 32
+    };
+	 */
+    
+    NSUInteger mask = [value unsignedIntegerValue];
+    NSMutableString *maskValue = [[[NSMutableString alloc] init] autorelease];
+	
+	if (mask == NSViewNotSizable)
+	{
+		[maskValue appendString:@"NSViewNotSizable"];
+	}
+    if ((mask & NSViewMinXMargin) == NSViewMinXMargin)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSViewMinXMargin"];
+    }
+    if ((mask & NSViewWidthSizable) == NSViewWidthSizable)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSViewWidthSizable"];
+    }
+    if ((mask & NSViewMaxXMargin) == NSViewMaxXMargin)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSViewMaxXMargin"];
+    }
+	if ((mask & NSViewMinYMargin) == NSViewMinYMargin)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSViewMinYMargin"];
+    }
+	if ((mask & NSViewHeightSizable) == NSViewHeightSizable)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSViewHeightSizable"];
+    }
+	if ((mask & NSViewMaxYMargin) == NSViewMaxYMargin)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSViewMaxYMargin"];
+    }
+    
+    return maskValue;
+}
+
+- (NSString *)borderTypeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSNoBorder",
+                       @"NSLineBorder",
+                       @"NSBezelBorder",
+					   @"NSGrooveBorder", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)colorString:(id)value
+{
+    NSMutableString *color = [[[NSMutableString alloc] init] autorelease];
+    if ([value hasPrefix:@"NSCalibratedRGBColorSpace"])
+    {
+        float red, green, blue, alpha;
+        sscanf([value UTF8String], "NSCalibratedRGBColorSpace %f %f %f %f", &red, &green, &blue, &alpha);
+        [color appendFormat:@"[NSColor colorWithCalibratedRed:(CGFloat)%f green:(CGFloat)%f blue:(CGFloat)%f alpha:(CGFloat)%1.1f]", red, green, blue, alpha];
+    }
+    else if ([value hasPrefix:@"NSCalibratedWhiteColorSpace"])
+    {
+        float white, alpha;
+        sscanf([value UTF8String], "NSCalibratedWhiteColorSpace %f %f", &white, &alpha);
+        [color appendFormat:@"[NSColor colorWithCalibratedWhite:(CGFloat)%f alpha:(CGFloat)%1.1f]", white, alpha];
+    }
+	else if ([value hasPrefix:@"NSDeviceRGBColorSpace"])
+    {
+        float red, green, blue, alpha;
+        sscanf([value UTF8String], "NSDeviceRGBColorSpace %f %f %f %f", &red, &green, &blue, &alpha);
+        [color appendFormat:@"[NSColor colorWithDeviceRed:(CGFloat)%f green:(CGFloat)%f blue:(CGFloat)%f alpha:(CGFloat)%1.1f]", red, green, blue, alpha];
+    }
+	else if ([value hasPrefix:@"NSNamedColorSpace"])
+    {
+		char listName[256], colorName[256];
+		sscanf([value UTF8String], "NSNamedColorSpace %s %s", &listName, &colorName);
+		[color appendFormat:@"[NSColor colorWithCatalogName:@\"%@\" colorName:@\"%@\"]", [NSString stringWithUTF8String:listName], [NSString stringWithUTF8String:colorName]];
+	}
+	else
+    {
+        [color appendString:value];
+    }
+    return color;
+}
+
+- (NSString *)floatString:(id)value
+{
+    return [NSString stringWithFormat:@"(CGFloat)%1.1f", [value floatValue]];
+}
+
+- (NSString *)focusRingTypeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSFocusRingTypeDefault",
+                       @"NSFocusRingTypeNone",
+                       @"NSFocusRingTypeExterior", nil];
+	NSUInteger index = [value unsignedIntegerValue];
+	NSUInteger count = [values count];
+	return (index < count) ? [values objectAtIndex:index] : nil;
+}
+
+- (NSString *)fontString:(id)value
+{
+	NSString *fontName = [value objectForKey:@"Name"];
+	float fontSize = [[value objectForKey:@"Size"] floatValue];
+	return [NSString stringWithFormat:@"[NSFont fontWithName:@\"%@\" size:(CGFloat)%1.1f]", fontName, fontSize];
+}
+
+- (NSString *)sizeString:(id)value
+{
+	NSSize size = NSSizeFromString(value);
+	return [NSString stringWithFormat:@"NSMakeSize((CGFloat)%1.1f, (CGFloat)%1.1f)", size.width, size.height];
+}
+
+@end

--- a/NibProcessor/Processors/AppKit/NSWindowTemplateProcessor.h
+++ b/NibProcessor/Processors/AppKit/NSWindowTemplateProcessor.h
@@ -1,0 +1,17 @@
+//
+//  NSWindowTemplateProcessor.h
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "Processor.h"
+
+@interface NSWindowTemplateProcessor : Processor
+
+- (NSString *)backingTypeString:(id)value;
+- (NSString *)sizeString:(id)value;
+- (NSString *)styleMaskString:(id)value;
+
+@end

--- a/NibProcessor/Processors/AppKit/NSWindowTemplateProcessor.m
+++ b/NibProcessor/Processors/AppKit/NSWindowTemplateProcessor.m
@@ -1,0 +1,165 @@
+//
+//  NSWindowTemplateProcessor.m
+//  nib2objc
+//
+//  Created by administrator on 3/8/12.
+//  Copyright 2012 1951FDG. All rights reserved.
+//
+
+#import "NSWindowTemplateProcessor.h"
+
+@implementation NSWindowTemplateProcessor
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (NSString *)getProcessedClassName
+{
+    return @"NSWindow";
+}
+
+- (NSString *)frameString
+{
+	NSPoint point = NSPointFromString([self.input objectForKey:@"contentRectOrigin"]);
+	NSSize size = NSSizeFromString([self.input objectForKey:@"contentRectSize"]);
+	return [NSString stringWithFormat:@"NSMakeRect((CGFloat)%1.1f, (CGFloat)%1.1f, (CGFloat)%1.1f, (CGFloat)%1.1f)", point.x, point.y, size.width, size.height];
+}
+
+- (NSString *)constructorString
+{
+	NSString *className = [self.input objectForKey:@"className"];
+	NSString *contentRect = [self frameString];
+	NSString *aStyle = [self styleMaskString:[self.input objectForKey:@"styleMask"]];
+	NSString *bufferingType = [self backingTypeString:[self.input objectForKey:@"backingType"]];
+	NSString *flag = ([[self.input objectForKey:@"deferred"] boolValue]) ? @"YES" : @"NO";
+	return [NSString stringWithFormat:@"[[%@ alloc] initWithContentRect:%@ styleMask:%@ backing:%@ defer:%@]", className, contentRect, aStyle, bufferingType, flag];
+}
+
+- (void)processKey:(id)item value:(id)value
+{
+	NSString *aString = nil;
+	if ([item isEqualToString:@"class"])
+    {
+        aString = [self getProcessedClassName];
+    }
+	else if ([item isEqualToString:@"allowsToolTipsWhenApplicationIsInactive"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"autorecalculatesKeyViewLoop"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"designableHasMaxSize"])
+	{
+		if ([value boolValue])
+		{
+			aString = [self sizeString:[self.input objectForKey:@"gMaxSize"]];
+			item = @"contentMaxSize";
+		}
+	}
+	else if ([item isEqualToString:@"designableHasMinSize"])
+	{
+		if ([value boolValue])
+		{
+			aString = [self sizeString:[self.input objectForKey:@"gMinSize"]];
+			item = @"contentMinSize";
+		}
+	}
+	else if ([item isEqualToString:@"hasShadow"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"hidesOnDeactivate"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"oneShot"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"releasedWhenClosed"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"showsToolbarButton"])
+	{
+		aString = ([value boolValue]) ? @"YES" : @"NO";
+	}
+	else if ([item isEqualToString:@"title"])
+	{
+		aString = [NSString stringWithFormat:@"@\"%@\"", value];
+	}
+	if (aString != nil)
+    {
+        [output setObject:aString forKey:item];
+    }
+}
+
+- (NSString *)backingTypeString:(id)value
+{
+	NSArray *values = [NSArray arrayWithObjects:@"NSBackingStoreRetained",
+                       @"NSBackingStoreNonretained",
+                       @"NSBackingStoreBuffered", nil];
+	return [values objectAtIndex:[value unsignedIntegerValue]];
+}
+
+- (NSString *)sizeString:(id)value
+{
+	NSSize size = NSSizeFromString(value);
+	return [NSString stringWithFormat:@"NSMakeSize((CGFloat)%1.1f, (CGFloat)%1.1f)", size.width, size.height];
+}
+
+- (NSString *)styleMaskString:(id)value
+{
+    /* From the documentation
+    enum 
+    {
+		NSTitledWindowMask = 1 << 0,
+		NSClosableWindowMask = 1 << 1,
+		NSMiniaturizableWindowMask = 1 << 2,
+		NSResizableWindowMask = 1 << 3,
+		NSTexturedBackgroundWindowMask = 1 << 8,
+		NSUnifiedTitleAndToolbarWindowMask = 1 << 12
+    };
+	 */
+    
+    NSUInteger mask = [value unsignedIntegerValue];
+    NSMutableString *maskValue = [[[NSMutableString alloc] init] autorelease];
+    
+    if ((mask & NSTitledWindowMask) == NSTitledWindowMask)
+    {
+        [maskValue appendString:@"NSTitledWindowMask"];
+    }
+    if ((mask & NSClosableWindowMask) == NSClosableWindowMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSClosableWindowMask"];
+    }
+    if ((mask & NSMiniaturizableWindowMask) == NSMiniaturizableWindowMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSMiniaturizableWindowMask"];
+    }
+    if ((mask & NSResizableWindowMask) == NSResizableWindowMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSResizableWindowMask"];
+    }
+	if ((mask & NSTexturedBackgroundWindowMask) == NSTexturedBackgroundWindowMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSTexturedBackgroundWindowMask"];
+    }
+	if ((mask & NSUnifiedTitleAndToolbarWindowMask) == NSUnifiedTitleAndToolbarWindowMask)
+    {
+        if ([maskValue length] > 0) [maskValue appendString:@" | "];
+        [maskValue appendString:@"NSUnifiedTitleAndToolbarWindowMask"];
+    }
+    
+    return maskValue;
+}
+
+@end

--- a/NibProcessor/Processors/Processor.m
+++ b/NibProcessor/Processors/Processor.m
@@ -210,7 +210,7 @@
         id value = [input objectForKey:item];
         [self processKey:item value:value];
 
-#ifdef CONFIGURATION_Debug
+#ifdef DEBUG
         // This will show properties not yet known by nib2objc
         if ([output objectForKey:item] == nil &&
             ![ignoredProperties containsObject:item])

--- a/NibProcessor/Processors/Processor.m
+++ b/NibProcessor/Processors/Processor.m
@@ -50,6 +50,25 @@
 #import "GLKViewProcessor.h"
 #import "ProxyObjectProcessor.h"
 
+#import "NSWindowTemplateProcessor.h"
+#import "NSViewProcessor.h"
+#import "NSCustomViewProcessor.h"
+#import "NSScrollViewProcessor.h"
+#import "NSScrollerProcessor.h"
+#import "NSCollectionViewProcessor.h"
+#import "NSBoxProcessor.h"
+#import "NSImageViewProcessor.h"
+#import "NSImageCellProcessor.h"
+#import "NSTextFieldProcessor.h"
+#import "NSTextFieldCellProcessor.h"
+#import "NSButtonProcessor.h"
+#import "NSButtonCellProcessor.h"
+#import "NSSearchFieldProcessor.h"
+#import "NSSearchFieldCellProcessor.h"
+#import "NSArrayControllerProcessor.h"
+#import "NSPopUpButtonProcessor.h"
+#import "NSPopUpButtonCellProcessor.h"
+
 @interface Processor (Protected)
 
 - (NSString *)getProcessedClassName;
@@ -103,6 +122,24 @@
     else if ([klass isEqualToString:@"IBUITapGestureRecognizer"]) processor = [[UITapGestureRecognizerProcessor alloc] init];
     else if ([klass isEqualToString:@"IBGLKView"]) processor = [[GLKViewProcessor alloc] init];
     else if ([klass isEqualToString:@"IBProxyObject"]) processor = [[ProxyObjectProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSWindowTemplate"]) processor = [[NSWindowTemplateProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSView"]) processor = [[NSViewProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSCustomView"]) processor = [[NSCustomViewProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSScrollView"]) processor = [[NSScrollViewProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSScroller"]) processor = [[NSScrollerProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSCollectionView"]) processor = [[NSCollectionViewProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSBox"]) processor = [[NSBoxProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSImageView"]) processor = [[NSImageViewProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSImageCell"]) processor = [[NSImageCellProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSTextField"]) processor = [[NSTextFieldProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSTextFieldCell"]) processor = [[NSTextFieldCellProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSButton"]) processor = [[NSButtonProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSButtonCell"]) processor = [[NSButtonCellProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSSearchField"]) processor = [[NSSearchFieldProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSSearchFieldCell"]) processor = [[NSSearchFieldCellProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSArrayController"]) processor = [[NSArrayControllerProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSPopUpButton"]) processor = [[NSPopUpButtonProcessor alloc] init];
+	else if ([klass isEqualToString:@"NSPopUpButtonCell"]) processor = [[NSPopUpButtonCellProcessor alloc] init];
 
     return [processor autorelease];
 }


### PR DESCRIPTION
If AppKit.framework is 'linked', the AppKit processors will distinguish default values for properties, and as such, output varies depending on build configuration.

Debug Output Example

``` Objective-C
NSView *view1 = [[[NSView alloc] initWithFrame:NSMakeRect((CGFloat)0.0, (CGFloat)0.0, (CGFloat)480.0, (CGFloat)272.0)] autorelease];
[view1 setAppleScriptEventHandlerNames:// unknown property: (
)];
[view1 setAppleScriptObjectID:// unknown property: 0];
[view1 setAppleScriptObjectName:// unknown property: ];
[view1 setAppleScriptScriptName:// unknown property: ];
[view1 setAppleScriptScriptScope:// unknown property: 0];
[view1 setAutoresizesSubviews:// default: YES];
[view1 setAutoresizingMask:NSViewMaxXMargin | NSViewMinYMargin];
[view1 setClassName:// unknown property: NSView];
[view1 setFocusRingType:// default: NSFocusRingTypeDefault];
[view1 setFrame:NSMakeRect((CGFloat)0.0, (CGFloat)0.0, (CGFloat)480.0, (CGFloat)272.0)];
[view1 setHidden:// default: NO];
[view1 setWantsLayer:// default: NO];
```

Release Output Example

``` Objective-C
NSView *view1 = [[[NSView alloc] initWithFrame:NSMakeRect((CGFloat)0.0, (CGFloat)0.0, (CGFloat)480.0, (CGFloat)272.0)] autorelease];
[view1 setAutoresizingMask:NSViewMaxXMargin | NSViewMinYMargin];
[view1 setFrame:NSMakeRect((CGFloat)0.0, (CGFloat)0.0, (CGFloat)480.0, (CGFloat)272.0)];
```
